### PR TITLE
Informa bublo pri preferoj de gastiganto

### DIFF
--- a/hosting/locale/eo/LC_MESSAGES/django.po
+++ b/hosting/locale/eo/LC_MESSAGES/django.po
@@ -653,6 +653,39 @@ msgstr "Priskribo"
 msgid "Family members"
 msgstr "Kunloĝantoj"
 
+#: templates/hosting/snippets/place_owner_anchors.html:5
+msgid "I'm hosting :)"
+msgstr "Mi gastigas :)"
+
+#: templates/hosting/snippets/place_owner_anchors.html:7
+msgid "I'm <b>not</b> hosting"
+msgstr "Mi <b>ne</b> gastigas"
+
+#: templates/hosting/snippets/place_owner_anchors.html:12
+msgid "&nbsp; and will be glad "
+msgstr "&nbsp; kaj volonte "
+
+#: templates/hosting/snippets/place_owner_anchors.html:14
+msgid ", but will be glad "
+msgstr ", sed volonte "
+
+#: templates/hosting/snippets/place_owner_anchors.html:20
+#, python-format
+msgid "to guide you around %(my_city)s"
+msgstr "ĉiĉeronos vin en %(my_city)s"
+
+#: templates/hosting/snippets/place_owner_anchors.html:24
+msgid " or "
+msgstr " aŭ "
+
+#: templates/hosting/snippets/place_owner_anchors.html:30
+msgid "to have a drink together"
+msgstr "trinkos ion kun vi"
+
+#: templates/hosting/snippets/place_owner_anchors.html:32
+msgid "to have a drink together in the city"
+msgstr "trinkos ion kun vi en la urbo"
+
 #: templates/hosting/profile_detail.html:9
 msgid "Deleted profile"
 msgstr "Nuligita profilo"

--- a/hosting/templates/hosting/place_detail.html
+++ b/hosting/templates/hosting/place_detail.html
@@ -14,30 +14,6 @@
     {% endif %}
 {% endblock %}
 
-{% block extra_js %}
-        <script type="text/javascript">
-            $(document).ready(function() {
-                notification = $('#status-anchors_notification').data("content");
-                $('.anchor-notify').popover(
-                    { trigger: "manual",
-                      html: true,
-                      content: notification });
-            });
-            function displayAnchorsNotification() {
-                blockSmallDescription = $('.description-small');
-                $('html, body').animate({ scrollTop: blockSmallDescription.offset().top - 10 }, 500);
-                origin = $('.anchor-notify'); 
-                origin.popover("show");
-                notify = origin.next('.popover');
-                origin.filter('.status').next('.popover').addClass('hidden-xs hidden-sm');
-                notify.animate({ opacity: 0.95 }, 600);
-                window.setTimeout(function() {
-                    notify.animate({ opacity: 0 }, 600, function() { origin.popover("hide") });
-                }, 5000);
-            }
-        </script>
-{% endblock %}
-
 {% block page %}
     <div class="row place-detail">
         <div class="col-xs-12 col-md-6 owner">

--- a/hosting/templates/hosting/place_detail.html
+++ b/hosting/templates/hosting/place_detail.html
@@ -14,6 +14,30 @@
     {% endif %}
 {% endblock %}
 
+{% block extra_js %}
+        <script type="text/javascript">
+            $(document).ready(function() {
+                notification = $('#status-anchors_notification').data("content");
+                $('.anchor-notify').popover(
+                    { trigger: "manual",
+                      html: true,
+                      content: notification });
+            });
+            function displayAnchorsNotification() {
+                blockSmallDescription = $('.description-small');
+                $('html, body').animate({ scrollTop: blockSmallDescription.offset().top - 10 }, 500);
+                origin = $('.anchor-notify'); 
+                origin.popover("show");
+                notify = origin.next('.popover');
+                origin.filter('.status').next('.popover').addClass('hidden-xs hidden-sm');
+                notify.animate({ opacity: 0.95 }, 600);
+                window.setTimeout(function() {
+                    notify.animate({ opacity: 0 }, 600, function() { origin.popover("hide") });
+                }, 5000);
+            }
+        </script>
+{% endblock %}
+
 {% block page %}
     <div class="row place-detail">
         <div class="col-xs-12 col-md-6 owner">
@@ -45,7 +69,7 @@
                                 {% endif %}
                             </a>
                         </p>
-                        <p class="col-xs-4 status">
+                        <p class="col-xs-4 status anchor-notify" data-placement="left" onclick="displayAnchorsNotification()">
                             {% if user.is_authenticated %}
                                 {% if place.tour_guide %}
                                     <img src="{% get_static_prefix %}img/city_guide.svg"
@@ -162,6 +186,8 @@
 
         {% if user.is_authenticated %}
             <div class="col-xs-12 hidden-md hidden-lg description-small">
+                <a id="status-anchors_notification" class="col-xs-12 anchor-notify" data-placement="bottom"
+                   data-content="{% include 'hosting/snippets/place_owner_anchors.html' %}"></a>
                 {% include 'hosting/snippets/place_description.html' with description=place.description contact_before=place.contact_before max_host=place.max_guest max_night=place.max_night %}
                 {% if place.conditions.all %}
                     {% include 'hosting/snippets/place_conditions.html' with conditions=place.conditions.all %}

--- a/hosting/templates/hosting/snippets/place_owner_anchors.html
+++ b/hosting/templates/hosting/snippets/place_owner_anchors.html
@@ -1,0 +1,39 @@
+{% spaceless %}
+{% load i18n %}
+
+{% if place.available %}
+    <em>{% trans "I'm hosting :)" %}</em>
+{% else %}
+    <em>{% trans "I'm <b>not</b> hosting" %}</em>
+{% endif %}
+
+{% if place.tour_guide or place.have_a_drink %}
+    {% if place.available %}
+        <em>{% trans "&nbsp; and will be glad " %}</em>
+    {% else %}
+        <em>{% trans ", but will be glad " %}</em>
+    {% endif %}
+
+    {% if place.tour_guide %}
+        {% with my_city=place.city|default:_("city") %}
+            <em>{% blocktrans trimmed %}
+                to guide you around {{ my_city }}
+            {% endblocktrans %}</em>
+        {% endwith %}
+        {% if place.have_a_drink %}
+            <em>{% trans " or " %}</em>
+        {% endif %}
+    {% endif %}
+    
+    {% if place.have_a_drink %}
+        {% if place.tour_guide %}
+            <em>{% trans "to have a drink together" %}</em>
+        {% else %}
+            <em>{% trans "to have a drink together in the city" %}</em>
+        {% endif %}
+    {% endif %}
+    
+    <em>.</em>
+{% endif %}
+
+{% endspaceless %}

--- a/pasportaservo/static/css/pasportaservo.css
+++ b/pasportaservo/static/css/pasportaservo.css
@@ -248,6 +248,29 @@ header.home form.search {
 .place-detail .owner .avatar {
     padding-right: 0;
 }
+.description-small {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+.anchor-notify + .popover {
+    color: #31708f;
+    background-color: #d9edf7;
+    border-color: #bce8f1;
+    opacity: 0.95;
+    text-align: center;
+}
+.anchor-notify + .popover.bottom > .arrow {
+    border-bottom-color: #bce8f1;
+}
+.anchor-notify + .popover.left > .arrow {
+    border-left-color: #bce8f1;
+}
+.anchor-notify + .popover.bottom > .arrow:after {
+    border-bottom-color: #d9edf7;
+}
+.anchor-notify + .popover.left > .arrow:after {
+    border-left-color: #d9edf7;
+}
 
 
 /* Accomodation */
@@ -280,10 +303,6 @@ p.tip {
 }
 .map iframe {
     /*height: 150px;*/
-}
-.description-small {
-    margin-top: 1em;
-    margin-bottom: 1em;
 }
 
 
@@ -362,6 +381,7 @@ header:not(.home) #subtitle {
     margin-top: -100px;
     overflow: hidden;
     position: fixed;
+    top: 0;
     opacity: 0.92;
     z-index: 1050;
     transition: margin-top 1s, opacity .8s linear; -webkit-transition: margin-top 1s, opacity .8s linear; -moz-transition: margin-top 1s, opacity .8s linear; -o-transition: margin-top 1s, opacity .8s linear;

--- a/pasportaservo/static/js/scripts.js
+++ b/pasportaservo/static/js/scripts.js
@@ -1,17 +1,17 @@
 $(document).ready(function(){
     // Kontraŭspamo
-    $("a[href^='mailto:']").each(function() {
-        $(this).attr("href", $(this).attr("href").replace(" [cxe] ", "@"));
+    $('a[href^="mailto:"]').each(function() {
+        $(this).attr('href', $(this).attr('href').replace(" [cxe] ", "@"));
         $(this).html($(this).html().replace(" [cxe] ", "@"));
     });
 
     // Close message
-    $("a.close").click(function(e) {
+    $('a.close').click(function(e) {
         $(this).hide();
-        $(this).parents(".message").slideUp();
+        $(this).parents('.message').slideUp();
         e.preventDefault();
     });
 
     // Lazy load images
-    $(".lazy").addClass("loaded");
+    $('.lazy').addClass('loaded');
 });

--- a/pasportaservo/static/js/scripts.js
+++ b/pasportaservo/static/js/scripts.js
@@ -1,4 +1,8 @@
-$(document).ready(function(){
+// @source: https://github.com/tejo-esperanto/pasportaservo/blob/master/pasportaservo/static/js/scripts.js
+// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL v3
+
+
+$(document).ready(function() {
     // Kontraŭspamo
     $('a[href^="mailto:"]').each(function() {
         $(this).attr('href', $(this).attr('href').replace(" [cxe] ", "@"));
@@ -14,4 +18,33 @@ $(document).ready(function(){
 
     // Lazy load images
     $('.lazy').addClass('loaded');
+    
+    // Host preferences popover setup
+    if ($('#status-anchors_notification')[0]) {
+        $('.anchor-notify').popover({
+            trigger: "manual",
+            html: true,
+            content: $('#status-anchors_notification').data("content") 
+        });
+    }
 });
+
+
+// Host preferences popover
+function displayAnchorsNotification() {
+    blockSmallDescription = $('.description-small');
+    $('html, body').animate({ scrollTop: blockSmallDescription.offset().top - 10 }, 500);
+    
+    origin = $('.anchor-notify');
+    origin.popover("show");
+    notify = origin.next('.popover');
+    origin.filter('.status').next('.popover').addClass('hidden-xs hidden-sm');
+    
+    notify.animate({ opacity: 0.95 }, 600);
+    window.setTimeout(function() {
+        notify.animate({ opacity: 0 }, 600, function() { origin.popover("hide") });
+    }, 5000);
+}
+
+
+// @license-end


### PR DESCRIPTION
La detala paĝo de ejo inkluzivas piktogramojn por ĉiĉeronado, trinkejumado, kaj disponebleco de loĝejo. Ĉe tradiciaj komputiloj (ni diru, muso-havaj) eblas restigi la musan indikilon ĉe la piktogramo por vidi la titolon. Tamen, en tuŝaparatoj (kaj aliaj ĉe kiuj ne eblas la antaŭa ago), persono povas resti konfuzita se ne jam konas la signifon de tiuj piktogramoj.

Tiu ĉi enmeto do aldonas bublon kiu detaligas kion la gastiganto proponas. Ĝi aperos maldekstre de la piktogramoj por larĝa ekrano kaj sub la mapo por eta ekrano, kaj aŭtomate malaperos post difinita tempa intervalo.